### PR TITLE
Update api_category.rb

### DIFF
--- a/lib/onfleet/api_category.rb
+++ b/lib/onfleet/api_category.rb
@@ -52,7 +52,7 @@ module Onfleet
     end
 
     def set_api_url
-      @api_url = URI.encode(@api_endpoint + @category_name)
+      @api_url = URI.encode(@api_endpoint + "/#{@category_name}")
     end
 
     def raise_error_with_message(parsed_response={})


### PR DESCRIPTION
Hello. I am a novice developer, so if something is wrong I ask Sorry.
  I downloaded your gem, but it is not working for me.

onfleet = Onfleet :: API.new
  => # <Onfleet :: API: 0x00000004b419b0api_key = "****************", @ api_endpoint = "https://onfleet.com/api/v2", @ timeout = 15, @ throws_exceptions = false,default_params = {}>
2.2.1: 002> onfleet.organization.all
  => {"Code" => "ResourceNotFound", "message" => {"error" => 1401, "message" => "This verb has not been implemented for the requested resource.", "Request" => "b8e45499-1d61-4d90-aaa5-bdd0c2e3cbaa "}}

When I started rabiratsya I found you in creating error @api_url
After adjustment it worked fine
